### PR TITLE
Make more routing work with iron-selector

### DIFF
--- a/more-route-selector.html
+++ b/more-route-selector.html
@@ -139,10 +139,13 @@ Polymer({
 
   _updateRoutes: function() {
     var routes = [];
-    if (this._managedSelector) {
-      routes = this._managedSelector.items.map(this._routeForItem.bind(this));
-    }
-    this._setRoutes(routes);
+    var _this = this;
+    setTimeout(function() {
+      if (_this._managedSelector) {
+        routes = _this._managedSelector.items.map(_this._routeForItem.bind(_this));
+      }
+      _this._setRoutes(routes);
+    }, 100);
   },
 
   _onMoreRouteChange: function(event) {


### PR DESCRIPTION
More routing is no longer maintained by the polymer team. This change is required to make more routing work with iron-selector version 1.0.8 and above.
